### PR TITLE
Sk/time

### DIFF
--- a/examples/demo_agent_based_seir.py
+++ b/examples/demo_agent_based_seir.py
@@ -27,7 +27,7 @@ pars = PropertySet(dict(
 
     # Time 
     start_date      = start_date,  # Start date of the simulation
-    timesteps       = 180,  # Number of timesteps
+    dur       = 180,  # Number of timesteps
 
     # Population
     n_ppl           = pop, # np.array([30000, 10000, 15000, 20000, 25000]),  

--- a/examples/demo_nigeria.py
+++ b/examples/demo_nigeria.py
@@ -88,7 +88,7 @@ pars = PropertySet(dict(
 
     # Time 
     start_date      = start_date,  # Start date of the simulation
-    timesteps       = n_days,  # Number of timesteps
+    dur             = n_days,  # Number of timesteps
 
     # Population 
     n_ppl           = pop, # np.array([30000, 10000, 15000, 20000, 25000]),  

--- a/examples/demo_zamfara.py
+++ b/examples/demo_zamfara.py
@@ -37,7 +37,7 @@ pars = PropertySet(dict(
 
     # Time 
     start_date      = start_date,  # Start date of the simulation
-    timesteps       = n_days,  # Number of timesteps
+    dur             = n_days,  # Number of timesteps
 
     # Population 
     n_ppl           = pop, # np.array([30000, 10000, 15000, 20000, 25000]),  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "rastertools @ git+https://github.com/InstituteforDiseaseModeling/RasterTools.git@76e4b737337449b103d8d9070248a970e9c05713",
     "requests",
     "scipy",
-    "sciris",
     "shapely",
     "tables",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "rastertools @ git+https://github.com/InstituteforDiseaseModeling/RasterTools.git",
     "requests",
     "scipy",
+    "sciris",
     "shapely",
     "tables",
     "tqdm",

--- a/scripts/profiling/profiling_spatial_seir.py
+++ b/scripts/profiling/profiling_spatial_seir.py
@@ -21,7 +21,7 @@ def make_sim(n_ppl=100e3, n_nodes=1, dur=365):
 
         # Time 
         start_date      = sc.date('2025-01-01'),  # Start date of the simulation
-        timesteps       = dur,  # Number of timesteps
+        dur             = dur,  # Number of timesteps
 
         # Population
         n_ppl           = pop, # np.array([30000, 10000, 15000, 20000, 25000]),  

--- a/src/laser_polio/__init__.py
+++ b/src/laser_polio/__init__.py
@@ -3,8 +3,8 @@ from .seir_abm import *
 from .utils import *
 from .distributions import *
 
-# import sciris as sc
-# root = sc.thispath(__file__).parent
-# del sc
+import sciris as sc
+root = sc.thispath(__file__).parent
+del sc
 
 __version__ = '0.1'

--- a/src/laser_polio/__init__.py
+++ b/src/laser_polio/__init__.py
@@ -3,8 +3,4 @@ from .seir_abm import *
 from .utils import *
 from .distributions import *
 
-import sciris as sc
-root = sc.thispath(__file__).parent
-del sc
-
 __version__ = '0.1'

--- a/src/laser_polio/seir_abm.py
+++ b/src/laser_polio/seir_abm.py
@@ -168,10 +168,10 @@ def count_SEIRP(node_id, disease_state, paralyzed, n_nodes):
     return S, E, I, R, P
 
 
-# @nb.njit(parallel=True)
+@nb.njit(parallel=True)
 def step_nb(disease_state, exposure_timer, infection_timer, acq_risk_multiplier, daily_infectivity, paralyzed, p_paralysis):
-    for i in np.arange(disease_state.size):
-    # for i in nb.prange(disease_state.size):
+    # for i in np.arange(disease_state.size):
+    for i in nb.prange(disease_state.size):
         # Update states in reverse order so that newly exposed don't become infected on the same timestep
         if disease_state[i] == 2:  # Infected
             if infection_timer[i] <= 0:

--- a/src/laser_polio/seir_abm.py
+++ b/src/laser_polio/seir_abm.py
@@ -316,13 +316,13 @@ class DiseaseState_ABM:
 
         #sc.printcyan(f'DiseaseState_ABM t={self.sim.t}')
 
-        exp_inx = np.where(self.sim.people.disease_state == 1)[0]
-        exp_timer = self.sim.people.exposure_timer[exp_inx]
+        #exp_inx = np.where(self.sim.people.disease_state == 1)[0]
+        #exp_timer = self.sim.people.exposure_timer[exp_inx]
         #print( f"DEBUG: {exp_inx=}" )
         #print( f"DEBUG: {exp_timer=}" )
 
-        inf_idx = np.where(self.sim.people.disease_state == 2)[0]
-        inf_timer = self.sim.people.infection_timer[inf_idx]
+        #inf_idx = np.where(self.sim.people.disease_state == 2)[0]
+        #inf_timer = self.sim.people.infection_timer[inf_idx]
         #print( f"DEBUG: {inf_idx=}" )
         #print( f"DEBUG: {inf_timer=}" )
 
@@ -579,13 +579,13 @@ class Transmission_ABM:
 
         #sc.printcyan(f'Transmission_ABM t={self.sim.t}')
 
-        exp_inx = np.where(self.sim.people.disease_state == 1)[0]
-        exp_timer = self.sim.people.exposure_timer[exp_inx]
+        #exp_inx = np.where(self.sim.people.disease_state == 1)[0]
+        #exp_timer = self.sim.people.exposure_timer[exp_inx]
         #print( f"DEBUG: {exp_inx=}" )
         #print( f"DEBUG: {exp_timer=}" )
 
-        inf_idx = np.where(self.sim.people.disease_state == 2)[0]
-        inf_timer = self.sim.people.infection_timer[inf_idx]
+        #inf_idx = np.where(self.sim.people.disease_state == 2)[0]
+        #inf_timer = self.sim.people.infection_timer[inf_idx]
         #print( f"DEBUG: {inf_idx=}" )
         #print( f"DEBUG: {inf_timer=}" )
 

--- a/src/laser_polio/seir_abm.py
+++ b/src/laser_polio/seir_abm.py
@@ -240,6 +240,12 @@ class DiseaseState_ABM:
         sim.people.add_scalar_property("infection_timer", dtype=np.int32, default=0)
         sim.people.infection_timer[:np.sum(self.pars.n_ppl)] = self.pars.dur_inf(np.sum(self.pars.n_ppl)) # initialize all agents with an infection_timer
 
+        sim.results.add_array_property("S", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
+        sim.results.add_array_property("E", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
+        sim.results.add_array_property("I", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
+        sim.results.add_array_property("R", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
+        sim.results.add_array_property("paralyzed", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
+
         # Initialize immunity
         if isinstance(pars.init_immun, float):
             # Initialize across total population
@@ -454,11 +460,6 @@ class Transmission_ABM:
 
         # Track disease states here because transmission will be the last component to run
         self.results = sim.results
-        sim.results.add_array_property("S", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
-        sim.results.add_array_property("E", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
-        sim.results.add_array_property("I", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
-        sim.results.add_array_property("R", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
-        sim.results.add_array_property("paralyzed", shape=(sim.nt, len(self.nodes)), dtype=np.float32)
 
         # Calcultate geographic R0 modifiers based on underweight data (one for each node)
         underwt = self.pars.beta_spatial  # Placeholder for now

--- a/src/laser_polio/seir_abm.py
+++ b/src/laser_polio/seir_abm.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numba as nb
-import sciris as sc
+#import sciris as sc
 import matplotlib.pyplot as plt
 from laser_core.laserframe import LaserFrame
 from laser_core.migration import gravity, row_normalizer
@@ -314,17 +314,17 @@ class DiseaseState_ABM:
             self.pars.p_paralysis
         )
 
-        sc.printcyan(f'DiseaseState_ABM t={self.sim.t}')
+        #sc.printcyan(f'DiseaseState_ABM t={self.sim.t}')
 
         exp_inx = np.where(self.sim.people.disease_state == 1)[0]
         exp_timer = self.sim.people.exposure_timer[exp_inx]
-        print( f"{exp_inx=}" )
-        print( f"{exp_timer=}" )
+        #print( f"DEBUG: {exp_inx=}" )
+        #print( f"DEBUG: {exp_timer=}" )
 
         inf_idx = np.where(self.sim.people.disease_state == 2)[0]
         inf_timer = self.sim.people.infection_timer[inf_idx]
-        print( f"{inf_idx=}" )
-        print( f"{inf_timer=}" )
+        #print( f"DEBUG: {inf_idx=}" )
+        #print( f"DEBUG: {inf_timer=}" )
 
     def log(self, t):
         pass
@@ -367,7 +367,7 @@ class DiseaseState_ABM:
             plt.show()
 
     def plot_infected_map(self, save=False, results_path=None, n_panels=6):
-        timepoints = np.linspace(0, self.nt - 1, n_panels, dtype=int)
+        timepoints = np.linspace(0, self.pars.dur, n_panels, dtype=int)
         
         rows, cols = 2, int(np.ceil(n_panels / 2))
         fig, axs = plt.subplots(rows, cols, figsize=(cols * 6, rows * 6), sharex=True, sharey=True)
@@ -577,17 +577,17 @@ class Transmission_ABM:
 
 
 
-        sc.printcyan(f'Transmission_ABM t={self.sim.t}')
+        #sc.printcyan(f'Transmission_ABM t={self.sim.t}')
 
         exp_inx = np.where(self.sim.people.disease_state == 1)[0]
         exp_timer = self.sim.people.exposure_timer[exp_inx]
-        print( f"{exp_inx=}" )
-        print( f"{exp_timer=}" )
+        #print( f"DEBUG: {exp_inx=}" )
+        #print( f"DEBUG: {exp_timer=}" )
 
         inf_idx = np.where(self.sim.people.disease_state == 2)[0]
         inf_timer = self.sim.people.infection_timer[inf_idx]
-        print( f"{inf_idx=}" )
-        print( f"{inf_timer=}" )
+        #print( f"DEBUG: {inf_idx=}" )
+        #print( f"DEBUG: {inf_timer=}" )
 
     def plot(self, save=False, results_path=None):
         pass

--- a/src/laser_polio/seir_mpm.py
+++ b/src/laser_polio/seir_mpm.py
@@ -15,14 +15,14 @@ class CompartmentalSEIR:
         self.pars = pars       
         self.nodes = np.arange(len(pars.n_ppl))
         self.t = 0
-        self.dates = sc.daterange(self.pars['start_date'], days=self.pars.timesteps)
+        self.dates = sc.daterange(self.pars['start_date'], days=self.pars.dur)
         
         # Initialize node-level state variables
         self.results = LaserFrame(capacity=1)
-        self.results.add_array_property("S", shape=(pars.timesteps, len(self.nodes)), dtype=np.float32)
-        self.results.add_array_property("E", shape=(pars.timesteps, len(self.nodes)), dtype=np.float32)
-        self.results.add_array_property("I", shape=(pars.timesteps, len(self.nodes)), dtype=np.float32)
-        self.results.add_array_property("R", shape=(pars.timesteps, len(self.nodes)), dtype=np.float32)
+        self.results.add_array_property("S", shape=(pars.dur, len(self.nodes)), dtype=np.float32)
+        self.results.add_array_property("E", shape=(pars.dur, len(self.nodes)), dtype=np.float32)
+        self.results.add_array_property("I", shape=(pars.dur, len(self.nodes)), dtype=np.float32)
+        self.results.add_array_property("R", shape=(pars.dur, len(self.nodes)), dtype=np.float32)
         
         # Initialize populations
         self.results.S[0, :] = pars.n_ppl
@@ -42,7 +42,7 @@ class CompartmentalSEIR:
         self.components.append(component)
 
     def run(self):
-        for tick in range(1, self.pars.timesteps):
+        for tick in range(1, self.pars.dur):
             for component in self.components:
                 component.step(tick)
             self.t += 1
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     pars = PropertySet(dict(
         # Time 
         start_date      = sc.date('2025-01-01'),  # Start date of the simulation
-        timesteps       = 180,  # Number of timesteps
+        dur             = 180,  # Number of timesteps
 
         # Population
         n_ppl           = np.array([30000, 10000, 15000, 20000, 25000]),

--- a/src/laser_polio/utils.py
+++ b/src/laser_polio/utils.py
@@ -289,7 +289,7 @@ def process_sia_schedule_polio(df, region_names, sim_start_date):
 
 
 def get_woy(sim):
-    time = sim.dates[sim.t]
+    time = sim.datevec[sim.t]
 
     if isinstance(time, dt.date):
         date = time

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -118,6 +118,12 @@ def test_progression_with_transmission():
     assert n_inf_t0 > 0
     assert n_rec_t0 > 0
 
+    inf_idx = np.where(sim.people.disease_state == 2)[0]
+    sim.people.infection_timer[inf_idx]
+
+    exp_inx = np.where(sim.people.disease_state == 1)[0]
+    sim.people.exposure_timer[exp_inx]
+
     # Run the simulation for one timestep
     sim.run()
     n_sus_t1 = np.sum(sim.people.disease_state == 0)

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -7,7 +7,7 @@ def setup_sim():
     """Initialize a test simulation with DiseaseState_ABM component."""
     pars = PropertySet(dict(
         start_date      = lp.date('2020-01-01'),
-        timesteps       = 30,
+        dur       = 30,
         n_ppl           = np.array([1000, 500]),  # Two nodes with populations
         cbr             = np.array([30, 25]),  # Birth rate per 1000/year
         beta_spatial    = np.array([0.5, 2.0]),  # Spatial transmission scalar (multiplied by global rate)
@@ -49,7 +49,7 @@ def test_progression_manual_seeding():
     # Setup sim with 0 infections
     pars = PropertySet(dict(
         start_date      = lp.date('2020-01-01'),
-        timesteps       = 1,
+        dur       = 1,
         n_ppl           = np.array([1000, 500]),  # Two nodes with populations
         cbr             = np.array([30, 25]),  # Birth rate per 1000/year
         beta_spatial    = np.array([0.5, 2.0]),  # Spatial transmission scalar (multiplied by global rate)
@@ -82,7 +82,7 @@ def test_progression_with_transmission():
     # Setup sim with 0 infections
     pars = PropertySet(dict(
         start_date      = lp.date('2020-01-01'),
-        timesteps       = 2,
+        dur       = 1,
         n_ppl           = np.array([1000, 500]),  # Two nodes with populations
         cbr             = np.array([30, 25]),  # Birth rate per 1000/year
         beta_spatial    = np.array([0.5, 2.0]),  # Spatial transmission scalar (multiplied by global rate)
@@ -143,7 +143,7 @@ def test_paralysis_probability():
     # Setup sim with 0 infections
     pars = PropertySet(dict(
         start_date      = lp.date('2020-01-01'),
-        timesteps       = 1,
+        dur       = 1,
         n_ppl           = np.array([10000, 5000]),  # Two nodes with populations
         cbr             = np.array([30, 25]),  # Birth rate per 1000/year
         beta_spatial    = np.array([0.5, 2.0]),  # Spatial transmission scalar (multiplied by global rate)

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -19,7 +19,7 @@ def setup_sim():
         p_paralysis     = 1 / 2000,  # 1% paralysis probability
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.DiseaseState_ABM(sim))
+    sim.components = [ lp.DiseaseState_ABM ]
     return sim
 
 # Test Initialization
@@ -61,7 +61,6 @@ def test_progression_manual_seeding():
         p_paralysis     = 1 / 2000,  # 1% paralysis probability
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.DiseaseState_ABM(sim))
     assert np.all(sim.people.exposure_timer[:pars['n_ppl'].sum()] == 1), 'The exposure timer was not initialized correctly'
     assert np.all(sim.people.infection_timer[:pars['n_ppl'].sum()] == 1), 'The infection timer was not initialized correctly'
     sim.people.disease_state[:sim.pars.n_ppl.sum()] = 1  # Set all to Exposed
@@ -105,8 +104,7 @@ def test_progression_with_transmission():
         max_migr_frac   = 0.01, # Fraction of population that migrates
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.DiseaseState_ABM(sim))
-    sim.add_component(lp.Transmission_ABM(sim))
+    sim.components = [ lp.DiseaseState_ABM, lp.Transmission_ABM ]
 
     # Ensure that there's a mix of disease states
     n_sus_t0 = np.sum(sim.people.disease_state == 0)
@@ -161,7 +159,7 @@ def test_paralysis_probability():
         p_paralysis     = 1 / 2000,  # 1% paralysis probability
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.DiseaseState_ABM(sim))
+    sim.components = [ lp.DiseaseState_ABM ]
     sim.people.disease_state[:sim.pars.n_ppl.sum()] = 1  # Set all to Exposed
     sim.run()
     exp_paralysis = int(pars.p_paralysis * pars.n_ppl.sum())

--- a/tests/test_seir_abm_init.py
+++ b/tests/test_seir_abm_init.py
@@ -8,7 +8,7 @@ def setup_sim():
     """Initialize SEIR sim for testing."""
     pars = PropertySet(dict(
         start_date  = lp.date('2020-01-01'),  # Start date of the simulation
-        timesteps   = 10, # Number of timesteps to run the simulation
+        dur   = 10, # Number of timesteps to run the simulation
         n_ppl       = np.array([1000, 500]),  # Two nodes with populations
         cbr         = np.array([30, 25]),  # Birth rate per 1000/year
     ))

--- a/tests/test_timers.py
+++ b/tests/test_timers.py
@@ -11,7 +11,7 @@ params = PropertySet(dict(
     population_size = 1000,
     init_prev = 0.01,
     infection_rate = 0.3,
-    timesteps = 100
+    dur = 100
 ))
 
 # def test_timers():

--- a/tests/test_transmission.py
+++ b/tests/test_transmission.py
@@ -7,7 +7,7 @@
 #     """Ensure that if all individuals are immune, no infections occur."""
 #     pars = PropertySet(dict(
 #         start_date  = lp.date('2020-01-01'),
-#         timesteps   = 30,
+#         dur   = 30,
 #         n_ppl       = np.array([1000, 500]),
 #         init_immun  = [1.0],  # 100% immune
 #         init_prev   = [0.0],  # No initial infections

--- a/tests/test_vital_dynamics.py
+++ b/tests/test_vital_dynamics.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from functools import partial
 import laser_polio as lp
 from laser_core.propertyset import PropertySet
 
@@ -14,7 +15,8 @@ def setup_sim(step_size=1):
         age_pyramid_path    = 'data/Nigeria_age_pyramid_2024.csv',  # From https://www.populationpyramid.net/nigeria/2024/
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.VitalDynamics_ABM(sim, step_size=step_size))
+    steppy_vd = partial( lp.VitalDynamics_ABM, step_size=step_size )
+    sim.components = [steppy_vd] 
     return sim
 
 # Test Initialization
@@ -103,7 +105,8 @@ def test_zero_birth_rate():
         age_pyramid_path    = 'data/Nigeria_age_pyramid_2024.csv',  # From https://www.populationpyramid.net/nigeria/2024/
     ))
     sim = lp.SEIR_ABM(pars)
-    sim.add_component(lp.VitalDynamics_ABM(sim, step_size=1))
+    steppy_vd = partial( lp.VitalDynamics_ABM, step_size=1 )
+    sim.components = [steppy_vd] 
     initial_population = sim.people.count
     sim.run()
     assert sim.people.count == initial_population  # No new births

--- a/tests/test_vital_dynamics.py
+++ b/tests/test_vital_dynamics.py
@@ -8,7 +8,7 @@ def setup_sim(step_size=1):
     """Initialize a small test simulation with birth & death tracking."""
     pars = PropertySet(dict(
         start_date          = lp.date('2020-01-01'),  # Start date of the simulation
-        timesteps           = 30, # Number of timesteps to run the simulation
+        dur           = 30, # Number of dur to run the simulation
         n_ppl               = np.array([1000, 500]),  # Two nodes with populations
         cbr                 = np.array([30, 25]),  # Birth rate per 1000/year
         age_pyramid_path    = 'data/Nigeria_age_pyramid_2024.csv',  # From https://www.populationpyramid.net/nigeria/2024/
@@ -38,7 +38,7 @@ def test_births_generated():
 
     dobs = sim.people.date_of_birth[:sim.people.count]  # Extract date_of_birth; only consider active individuals
     dobs = dobs[dobs >= 0]  # Remove negatives (pop initialized before sim)
-    expected_births = np.bincount(dobs, minlength=sim.pars.timesteps) # Tally births per day
+    expected_births = np.bincount(dobs, minlength=sim.pars.dur) # Tally births per day
     observed_births = np.sum(sim.results.births, axis=1)  # Sum across nodes per timestep
     assert np.array_equal(expected_births, observed_births), 'Births did not occur on the expected days'
     print('Births:', sim.results.births)
@@ -53,7 +53,7 @@ def test_deaths_occur_step_size_1():
     assert np.all(sim.people.disease_state[:5] == -1), 'First 5 were not marked dead with disease_state'
 
     dods = sim.people.date_of_death[:sim.people.count]  # Extract date_of_death; only consider active individuals
-    expected_deaths = np.bincount(dods)[:sim.pars.timesteps]  # Tally deaths per day
+    expected_deaths = np.bincount(dods)[:sim.pars.dur]  # Tally deaths per day
     observed_deaths = np.sum(sim.results.deaths, axis=1)  # Sum across nodes per timestep
     assert np.array_equal(expected_deaths, observed_deaths), 'Deaths did not occur on the expected days'
 
@@ -71,11 +71,11 @@ def test_deaths_occur_step_size_7():
     assert np.all(sim.people.disease_state[:5] == -1), 'First 5 were not marked dead with disease_state'
 
     # Check that deaths occurred on the correct dates and were correctly aggregated into weekly bins
-    bin_edges = np.arange(0, sim.pars.timesteps + 1, 7)  # Define bin edges
+    bin_edges = np.arange(0, sim.pars.dur + 1, 7)  # Define bin edges
     dods = sim.people.date_of_death[:sim.people.count]  # Extract date_of_death for active individuals
-    expected_deaths = np.bincount(dods, minlength=sim.pars.timesteps)[:sim.pars.timesteps]  # Daily expected deaths
+    expected_deaths = np.bincount(dods, minlength=sim.pars.dur)[:sim.pars.dur]  # Daily expected deaths
     observed_deaths = np.sum(sim.results.deaths, axis=1)  # Daily observed deaths
-    death_bins = np.digitize(np.arange(sim.pars.timesteps), bin_edges, right=True)  # Digitize days into bins
+    death_bins = np.digitize(np.arange(sim.pars.dur), bin_edges, right=True)  # Digitize days into bins
     expected_deaths_binned = np.bincount(death_bins, weights=expected_deaths)[:len(bin_edges)-1]  # Aggregate deaths per bin
     observed_deaths_binned = np.bincount(death_bins, weights=observed_deaths)[:len(bin_edges)-1]  # Aggregate deaths per bin
     assert np.array_equal(expected_deaths_binned, observed_deaths_binned), 'Deaths did not occur on the expected days'  
@@ -90,14 +90,14 @@ def test_age_progression():
     initial_ages = sim.t - sim.people.date_of_birth[:np.sum(sim.pars.n_ppl)]  # Only focus on active individuals. Unborn agents don't age until born
     sim.run()
     end_ages = sim.t - sim.people.date_of_birth[:np.sum(sim.pars.n_ppl)]
-    assert np.all(end_ages == initial_ages + sim.pars.timesteps)
+    assert np.all(end_ages == initial_ages + sim.pars.dur)
 
 # Test Edge Case: Zero Birth Rate
 def test_zero_birth_rate():
     """Ensure that setting birth rate to zero prevents population growth."""
     pars = PropertySet(dict(
         start_date          = lp.date('2020-01-01'),  # Start date of the simulation
-        timesteps           = 30, # Number of timesteps to run the simulation
+        dur           = 30, # Number of dur to run the simulation
         n_ppl               = np.array([1000, 500]),  # Two nodes with populations
         cbr                 = np.array([0]),  # Birth rate per 1000/year
         age_pyramid_path    = 'data/Nigeria_age_pyramid_2024.csv',  # From https://www.populationpyramid.net/nigeria/2024/


### PR DESCRIPTION
This PR aims to align how starsim handles time and the order of operations (https://github.com/starsimhub/starsim/blob/main/starsim/loop.py). This should allow us to align with the other PR on order of operations (e.g., vital rates, then disease state changes, then interventions, then transmission). 

1. I updated the names of the time components. timesteps -> dur; sim.nt holds the length of the timesteps which is dur + 1 (this allows us to capture the initial conditions + dur number of additional days; and I changed the name of sim.dates to sim.datevec
2. I messed with the order of operations in step_nb. We now update infections before exposures. This prevents people that just became infected from losing a day of infection. And I decrement their timers after checking if <=0 so that infections on day 0 of the sim don't lose the ability to infect in transmission on day 0. 
3. I also moved count_SEIRP out of DiseaseState and into Transmission. This feels like a really odd choice, but it allows us to count people that just got exposed after transmission. I don't love it, but it works. We should consider alternatives, like having a dedicated logger that runs after Transmission. 




 