### PR TITLE
Only logging results on t=0, don't run step(). Updated timer logic to…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 # Note the order is intentional to avoid multiple passes of the hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0 # Use the version you want
+    rev: v5.0.0 # Use the version you want
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=100000"]

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # Priorities
-- Fix last two tests in test_diseasestate_abm.py
 - Add test for squashing
 - Track down what happened to the priority ordering
     # Set the order in which components should be run during step()
@@ -12,7 +11,7 @@
     ]
 - Rename variables to distinguish between exposure and infection
 - Testing
-    - DiseaseState_abm
+    - Squashing
     - Transmission_abm
     - RI_abm
     - SIA_abm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "rastertools @ git+https://github.com/InstituteforDiseaseModeling/RasterTools.git@76e4b737337449b103d8d9070248a970e9c05713",
     "requests",
     "scipy",
+    "sciris==3.1.7",
     "shapely",
     "tables",
     "tqdm",
@@ -115,6 +116,7 @@ ignore = [
     "PTH119", # I have no desire to think about paths as objects
     "PTH122", # I have neither desire nor need to think about paths as objects
     "PTH123", # I have neither desire nor need to think about paths as objects
+    "PTH208",
     "DTZ002" # I want to be able to just call a today() function.
 ]
 select = [

--- a/src/laser_polio/faster_transmission.py
+++ b/src/laser_polio/faster_transmission.py
@@ -208,7 +208,7 @@ class Transmission_ABM:
         L = np.linalg.cholesky(cov_matrix)  # Cholesky decomposition
         # Generate standard normal samples
         if not hasattr(self.people, "true_capacity"):
-            self.people.true_capacity = self.people.capacity # Ensure true_capacity is set even if we don't initialize prevalence by node
+            self.people.true_capacity = self.people.capacity  # Ensure true_capacity is set even if we don't initialize prevalence by node
         n_samples = self.people.true_capacity
         z = np.random.normal(size=(n_samples, 2))
         z_corr = z @ L.T  # Apply Cholesky to introduce correlation

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -1,5 +1,6 @@
 import numpy as np
 from laser_core.propertyset import PropertySet
+
 import laser_polio as lp
 
 
@@ -125,10 +126,14 @@ def test_progression_with_transmission():
     n_e_init = np.sum(disease_state == 1)
     n_i_init = np.sum(disease_state == 2)
     n_r_init = np.sum(disease_state == 3)
-    assert np.isclose(n_s_init, sim.pars.n_ppl.sum() * (1 - sim.pars.init_immun) * (1-sim.pars.init_prev), atol=10), "Roughly 18% of the pop should be S"
-    assert n_e_init == 0, 'There should be no E during initialization'
+    assert np.isclose(n_s_init, sim.pars.n_ppl.sum() * (1 - sim.pars.init_immun) * (1 - sim.pars.init_prev), atol=10), (
+        "Roughly 18% of the pop should be S"
+    )
+    assert n_e_init == 0, "There should be no E during initialization"
     assert np.isclose(n_i_init, sim.pars.n_ppl.sum() * (sim.pars.init_prev), atol=5), "Roughly 10% of the population should be infected"
-    assert np.isclose(n_r_init, sim.pars.n_ppl.sum() * (sim.pars.init_immun) * (1-sim.pars.init_prev), atol=5), "Roughly 72% of the pop should be R (since infections can override immunity in initialization)"
+    assert np.isclose(n_r_init, sim.pars.n_ppl.sum() * (sim.pars.init_immun) * (1 - sim.pars.init_prev), atol=5), (
+        "Roughly 72% of the pop should be R (since infections can override immunity in initialization)"
+    )
 
     # Run the simulation for one timestep
     sim.run()
@@ -183,7 +188,7 @@ def test_progression_with_transmission():
     assert n_r_t4 == n_r_t3 + n_i_t3, "R counts should be higher since I's should've become R"
 
     # Check disease states at the end of day 5
-    n_s_t5 = sim.results.S[5].sum() 
+    n_s_t5 = sim.results.S[5].sum()
     n_e_t5 = sim.results.E[5].sum()
     n_i_t5 = sim.results.I[5].sum()
     n_r_t5 = sim.results.R[5].sum()

--- a/tests/test_vital_dynamics.py
+++ b/tests/test_vital_dynamics.py
@@ -50,6 +50,11 @@ def test_births_generated():
     dobs = dobs[dobs >= 0]  # Remove negatives (pop initialized before sim)
     expected_births = np.bincount(dobs, minlength=sim.pars.dur + 1)  # Tally births per day, add 1 since results include init conditions and dur timesteps
     observed_births = np.sum(sim.results.births, axis=1)  # Sum across nodes per timestep
+    # Combine births on day 0 and day 1 since we don't run vital rates on day 0, we only log results
+    expected_births[1] += expected_births[0]  # Combine day 0 and day 1
+    expected_births = expected_births[1:]  # Remove day 0 since it's combined with day 1
+    observed_births[1] += observed_births[0]  # Combine day 0 and day 1
+    observed_births = observed_births[1:]  # Remove day 0 since it's combined with day 1
     assert np.array_equal(expected_births, observed_births), "Births did not occur on the expected days"
     # print("Births:", sim.results.births)
 

--- a/tests/test_vital_dynamics.py
+++ b/tests/test_vital_dynamics.py
@@ -48,7 +48,8 @@ def test_births_generated():
 
     dobs = sim.people.date_of_birth[: sim.people.count]  # Extract date_of_birth; only consider active individuals
     dobs = dobs[dobs >= 0]  # Remove negatives (pop initialized before sim)
-    expected_births = np.bincount(dobs, minlength=sim.pars.dur + 1)  # Tally births per day, add 1 since results include init conditions and dur timesteps
+    # Tally births per day, add 1 since results include init conditions and dur timesteps
+    expected_births = np.bincount(dobs, minlength=sim.pars.dur + 1)
     observed_births = np.sum(sim.results.births, axis=1)  # Sum across nodes per timestep
     # Combine births on day 0 and day 1 since we don't run vital rates on day 0, we only log results
     expected_births[1] += expected_births[0]  # Combine day 0 and day 1
@@ -69,7 +70,8 @@ def test_deaths_occur_step_size_1():
     assert np.all(sim.people.disease_state[:5] == -1), "First 5 were not marked dead with disease_state"
 
     dods = sim.people.date_of_death[: sim.people.count]  # Extract date_of_death; only consider active individuals
-    expected_deaths = np.bincount(dods)[: sim.pars.dur + 1]  # Tally deaths per day, add 1 since results are include init conditions and dur timesteps
+    # Tally deaths per day, add 1 since results are include init conditions and dur timesteps
+    expected_deaths = np.bincount(dods)[: sim.pars.dur + 1]
     observed_deaths = np.sum(sim.results.deaths, axis=1)  # Sum across nodes per timestep
     assert np.array_equal(expected_deaths, observed_deaths), "Deaths did not occur on the expected days"
 


### PR DESCRIPTION
Changes: 
1. On day 0, we only log results and increment the time, we do not run the component step() functions. This allows us to save the initial conditions. 
2. I updated step_nb() to correctly move agents through states. Previously, agents that just became I would stay an extra day in I because they E was getting updated after I. 
3. I moved any births on day 0 to one day prior. This addresses the fact that we're not running step() on day 0 anymore.