### PR TITLE
reporting updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 # Note the order is intentional to avoid multiple passes of the hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ NEW FEATURES
 
 
 # Refinement
+- Move setup_sim.py into src/laser_polio, rework demo_nigeria & demo_zamfara, use setup_sim for testing. Maybe with option to return pars before setup?
 - Is there a way to only load data & initialize sims once during calibration? How much speedup could we get?
 - John G recommends Finite Radiation model as default assumption
 - Work with John G to put bounds on gravity model pars??

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -1,4 +1,5 @@
 import time
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 
@@ -124,7 +125,7 @@ class SEIR_ABM:
 
     def run(self):
         sc.printcyan("Initialization complete. Running simulation...")
-        self.component_times = dict.fromkeys(self.instances, 0.0)
+        self.component_times = defaultdict(float)  # Initialize component times
         self.component_times["report"] = 0
         with alive_bar(self.nt, title="Simulation progress:") as bar:
             for tick in range(self.nt):
@@ -137,19 +138,19 @@ class SEIR_ABM:
                         start_time = time.perf_counter()
                         component.step()
                         end_time = time.perf_counter()
-                        self.component_times[component] += end_time - start_time
+                        self.component_times[component.__class__.__name__ + ".step()"] += end_time - start_time
 
-                    start_time = time.perf_counter()
                     self.log_results(tick)
-                    end_time = time.perf_counter()
-                    self.component_times["report"] += end_time - start_time
                     self.t += 1
                 bar()  # Update the progress bar
         sc.printcyan("Simulation complete.")
 
     def log_results(self, t):
         for component in self.instances:
+            start_time = time.perf_counter()
             component.log(t)
+            end_time = time.perf_counter()
+            self.component_times[component.__class__.__name__ + ".log()"] += end_time - start_time
 
     def plot(self, save=False, results_path=None):
         if save:
@@ -165,17 +166,17 @@ class SEIR_ABM:
         self.plot_node_pop(save=save, results_path=results_path)
 
         if self.component_times:
-            labels = [component.__class__.__name__ for component in self.instances]
-            labels.append("report")
             if self.verbose > 0.1:
                 print(f"{self.instances=}")
-                print(f"{labels=}")
-            # times = [self.component_times[component] for component in labels ]
-            times = [self.component_times[component] for component in self.instances]
-            times.append(self.component_times["report"])  # hack
-            plt.figure(figsize=(6, 6))
-            plt.pie(times, labels=labels, autopct="%1.1f%%", startangle=140, colors=plt.cm.Paired.colors)
-            plt.title("Time Spent in Each Component")
+            plt.figure(figsize=(12, 12))
+            plt.pie(
+                self.component_times.values(),
+                labels=self.component_times.keys(),
+                autopct="%1.1f%%",
+                startangle=140,
+                colors=plt.cm.Paired.colors,
+            )
+            plt.title(f"Time Spent in Each Component ({sum(self.component_times.values()):.2f} seconds)")
             if save:
                 plt.savefig(results_path / "perfpie.png")
             if not save:

--- a/tests/test_squashing.py
+++ b/tests/test_squashing.py
@@ -148,14 +148,30 @@ def test_squash():
     obs_r = sim.results.R[0].sum()
     assert np.isclose(exp_r, obs_r, atol=4000), f"Expected results.R size {exp_r}, but got {obs_r}."
 
-    init_R = np.sum(sim.results.R[-1])
+    # Test that mortality is occurring in R due to squashing/EULAgizing
+    R_before_run = sim.results.R.copy()
+    assert np.all(R_before_run[-1] < R_before_run[0]), "Recovereds should decline in all nodes due to mortality."
+
+    # TODO test amount of mortality
 
     # Run the simulation
     sim.run()
 
+    # Test results shape
+    R_after_run = sim.results.R.copy()
+    assert R_after_run.shape[0] == sim.nt, "Results shape mismatch: expected number of days."
+    assert R_after_run.shape[1] == len(sim.nodes), "Results shape mismatch: expected number of nodes."
+
     # Ensure that the number of R increased due to transmission
-    end_R = np.sum(sim.results.R[-1])
-    assert end_R > init_R, "The number of recovered individuals should have increased after running the simulation."
+    assert np.sum(R_after_run[-1]) > np.sum(R_before_run[-1]), (
+        "The number of recovered individuals should have increased after running the simulation."
+    )
+
+    # Ensure that the nodes with changes in recovered counts also had infections
+    R_delta = R_after_run[-1] - R_before_run[-1]
+    nodes_with_R = np.where(R_delta > 0)[0]  # Get the indices of nodes with recoveries
+    nodes_with_I = np.where(np.sum(sim.results.I, axis=0) > 0)[0]  # Get the indices of nodes with infections
+    assert np.all(np.isin(nodes_with_R, nodes_with_I)), "Some nodes with recoveries are not within the nodes with infections."
 
 
 if __name__ == "__main__":

--- a/tests/test_squashing.py
+++ b/tests/test_squashing.py
@@ -10,10 +10,10 @@ This test is based on examples/demo_nigeria.py
 
 regions = ["ZAMFARA"]
 start_year = 2019
-n_days = 5
+n_days = 60
 pop_scale = 1 / 100
 init_region = "ANKA"
-init_prev = 0.001
+init_prev = 0.05
 r0 = 14
 results_path = "results/demo_zamfara"
 


### PR DESCRIPTION
Provide a little more detail in the time reporting pie-chart (`step()` vs. `log()`).
Speed up `count_SEIRP()` a bit.

|System|branch|script|population|sim.run() time|
|-|-|-|-|-|
|Lenovo X31|main|demo_nigeria.py|100%|8:01.6|
|Lenovo X31|reporting-updates|demo_nigeria.py|100%|3:48.9|
|MacBook Pro|main|demo_nigeria.py|100%|4:45.9|
|MacBook Pro|reporting-updates|demo_nigeria.py|100%|1:43.5|

![perfpie](https://github.com/user-attachments/assets/b25c7161-f1c9-4dbf-a160-864f074f7437)
