### PR TITLE
Reorder version prompt

### DIFF
--- a/.github/workflows/manual-version-bump.yml
+++ b/.github/workflows/manual-version-bump.yml
@@ -4,11 +4,11 @@ on:
     workflow_dispatch:
       inputs:
         version_type:
-          description: 'Type of version bump (patch, minor, major)'
+          description: 'Type of version bump (major, minor, patch):'
           required: true
           default: 'patch'
         dry_run:
-          description: 'Dry run (true/false)'
+          description: 'Dry run (true/false):'
           required: false
           default: 'false'
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # PRIORITIES
 
 CALIBRATION
-- how do I stop a calib that's running? 
+- how do I stop a calib that's running?
 - print number of jobs that are about to start
 - how many jobs can I run? what's the optimal setup?
 - update how calib results path is passed from cloud vs to calibrate - don't think it's working. Can test it when they're unequal.


### PR DESCRIPTION
Makes the prompt in version bump match the order of version numbers: major.minor.patch