### PR TITLE
Sk/debug seed schedule

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 @Steve
 - Update default kube config file
-- Test that seed_schedule infection can infect & that seeds are infectious (timers & infectivity)
+- Set RI to zero
 - Stochastic tests
 - New model features
 - Run logger with radiation_k and validate

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -419,8 +419,8 @@ def step_nb(disease_state, exposure_timer, infection_timer, acq_risk_multiplier,
         if disease_state[i] == 2:  # Infected
             if infection_timer[i] <= 0:
                 disease_state[i] = 3  # Become recovered
-                acq_risk_multiplier[i] = 0.0  # Reset risk
-                daily_infectivity[i] = 0.0  # Reset infectivity
+                # acq_risk_multiplier[i] = 0.0  # Reset risk
+                # daily_infectivity[i] = 0.0  # Reset infectivity
             infection_timer[i] -= 1  # Decrement infection timer so that they recover on the next timestep
 
     return
@@ -804,9 +804,20 @@ class DiseaseState_ABM:
                     raise ValueError(f"Unsupported seed value type: {type(value)}")
                 if n_seed > 0:
                     selected = np.random.choice(candidates, size=n_seed, replace=False)
-                    self.people.disease_state[selected] = 2  # Set to infectious
+                    self.people.disease_state[selected] = 2  # Set to infectious regardless of current state
+                    # If people were previously infected, we'll need to give them an infection timer again
+                    inf_timer = self.people.infection_timer[selected]
+                    inds_zero_timers = selected[np.where(inf_timer <= 0)]
+                    self.sim.people.infection_timer[inds_zero_timers] = self.pars.dur_inf(len(inds_zero_timers))
                     if self.verbose >= 1:
                         print(f"[DiseaseState_ABM] t={t}: Seeded {n_seed} infections in node {node_id}")
+                        # daily_infectivity = self.people.daily_infectivity[selected]
+                        # inf_timer = self.people.infection_timer[selected]
+                        # len(selected)
+                        # daily_infectivity.min()
+                        # daily_infectivity.mean()
+                        # inf_timer.min()
+                        # inf_timer.mean()
 
         # Optional early stopping rule if no cases or seed_schedule events remain
         if self.pars["stop_if_no_cases"]:


### PR DESCRIPTION
I found a few bugs with seed_schedule. They explain why the second infection in 2020 never took off in my previous sims. 
 
In seed_schedule, we infecte people in the population regardless of their current disease state. The problem is that several of those folks may have been infected at this point in the sim. So that meant they had infection timers of -1 and their acquisition risk and daily_infectivity were set to 0. 
 
I updated the seed_schedule so that it draws new infection timers for people who've been previously infected. I also changed the code so that acquisition risk and daily infectivity don't get set to 0 upon recovery. That shouldn't have any other impacts on the sim since we always filter on disease_state before looking at acquisition risk or infectivity. 