### PR TITLE
Reduce testing and test time for wheel building

### DIFF
--- a/.github/workflows/manual-version-bump.yml
+++ b/.github/workflows/manual-version-bump.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest] # , windows-latest, macos-latest]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
We're really only running on Linux for the time being.
Should save ~3 minutes.
fixes #95 