### PR TITLE
Node seeding overdispersion

### DIFF
--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -1076,11 +1076,17 @@ def tx_step_prep_nb(
         elif beta_by_node_pre[i] == 0:
             # Over-disperse seeded infections to make takeoff more challenging
             # Apply only to nodes with zero local transmission. All infectivity is coming from neighboring nodes.
+
+            # Handle edge case where zero inflation is 100%
+            if node_seeding_zero_inflation >= 1.0:
+                new_infections[i] = 0
+                continue
             
-            # Target mean number of infections (exposure), scaled up to compensate for zeros
+            # Adjust mean to account for expected zero inflation
             desired_mean = exposure_by_node[i] / (1 - node_seeding_zero_inflation)  # E[X] matches Poisson on average, increased for zero-inflation
-            r_int = max(1, int(np.round(node_seeding_dispersion)))  # Dispersion parameter (r): controls variance
-            p = r_int / (r_int + desired_mean)  # Compute success probability for negative binomial. Matching mean
+            # Compute dispersion and success probability for Negative Binomial
+            r_int = max(1, int(np.round(node_seeding_dispersion)))
+            p = r_int / (r_int + desired_mean)
 
             # Apply zero inflation
             if np.random.rand() < node_seeding_zero_inflation:

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -1028,6 +1028,8 @@ def tx_step_prep_nb(
     r0_scalars,  # per node R0 scaling factor
     alive_counts,  # number of alive agents per node (for scaling)
     risks,  # per agent susceptibility (heterogeneous)
+    node_seeding_dispersion,
+    node_seeding_zero_inflation,
 ):
     # Step 1: Use parallelized loop to obtain per node sums or counts of:
     #  - exposure (susceptibility/node)
@@ -1045,7 +1047,8 @@ def tx_step_prep_nb(
             tl_sus_by_node[tid, nid] += 1
         if state == 2:
             tl_beta_by_node[nb.get_thread_id(), node_ids[i]] += daily_infectivity[i]
-    beta_by_node = tl_beta_by_node.sum(axis=0)  # Sum across threads
+    beta_by_node_pre = tl_beta_by_node.sum(axis=0)  # Sum across threads
+    beta_by_node = beta_by_node_pre.copy()  # Copy to avoid modifying the original
     exposure_by_node = tl_exposure_by_node.sum(axis=0)
     sus_by_node = tl_sus_by_node.sum(axis=0)  # Sum across threads
 
@@ -1068,7 +1071,20 @@ def tx_step_prep_nb(
     # Step 5: Compute the number of new infections per node
     new_infections = np.empty(num_nodes, dtype=np.int32)
     for i in nb.prange(num_nodes):
-        new_infections[i] = np.random.poisson(exposure_by_node[i])
+        if exposure_by_node[i] == 0:
+            new_infections[i] = 0
+        elif beta_by_node_pre[i] == 0:
+            # Seeding infections in a node, over-disperse to make takeoff more challenging
+            desired_mean = exposure_by_node[i] / (1 - node_seeding_zero_inflation)  # Matches poisson, increased for zero-inflation
+            r_int = max(1, int(np.round(node_seeding_dispersion)))
+            p = r_int / (r_int + desired_mean)  # Matching mean
+
+            if np.random.rand() < node_seeding_zero_inflation:
+                new_infections[i] = 0
+            else:
+                new_infections[i] = np.random.negative_binomial(r_int, p)
+        else:
+            new_infections[i] = np.random.poisson(exposure_by_node[i])  # Business as usual
 
     return beta_by_node, base_prob_inf, exposure_by_node, new_infections, sus_by_node
 
@@ -1377,6 +1393,8 @@ class Transmission_ABM:
                 self.r0_scalars,
                 alive_counts,
                 risk,
+                self.sim.pars.node_seeding_dispersion,
+                self.sim.pars.node_seeding_zero_inflation,
             )
 
             # Manual validation

--- a/src/laser_polio/pars.py
+++ b/src/laser_polio/pars.py
@@ -38,6 +38,8 @@ default_pars = PropertySet(
         "node_lookup": None,  # Node info (node_id are keys, dict contains dot_name, lat, lon)
         "distances": np.array([[0, 100], [100, 0]]),  # Distance in km between nodes
         # Migration
+        "node_seeding_dispersion": 1000,  # INTEGER (or will round) - negative binomial "k" parameter for the first importation into each node. Larger values -> Poisson.
+        "node_seeding_zero_inflation": 0.0,  # Fraction of node seeding events to zero out, float value between 0 and 1; 0.0 -> no zero inflation.
         "migration_method": "radiation",  # Migration method: "gravity" or "radiation"
         "radiation_k": 0.5,  # Radiation model scaling constant. Based on testing, this value should be between 0.0 and ~3 for Nigeria.
         "gravity_k": 1.0,  # Gravity scaling constant


### PR DESCRIPTION
New parameters:
  - `node_seeding_dispersion`
  - `node_seeding_zero_inflation`

These values apply only to nodes with zero local transmission. All infectivity is coming from neighboring nodes.

Large values of the node_seeding_dispersion and zero for node_seeding_zero_inflation approximate the original Posssion, although we may want to introduce a binary switch for this feature.