### PR TITLE
Update laser-core dependency to 0.4.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: '^(\.tox|ci/templates|\.bumpversion\.cfg)(/|$)'
 # Note the order is intentional to avoid multiple passes of the hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.11.11
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "geopandas",
     "geopy",
     "h5py",
-    "laser-core~=0.2",
+    "laser-core==0.4.1",
     "matplotlib",
     "numba>=0.59.1",
     "numpy>=1.26.4,<2.0.0",

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -133,7 +133,7 @@ class SEIR_ABM:
             # Load default parameters and optionally override with user-specified ones
             self.pars = deepcopy(lp.default_pars)
             if pars is not None:
-                self.pars += pars  # override default values
+                self.pars <<= pars  # override default values
             pars = self.pars
 
             self.verbose = pars["verbose"] if "verbose" in pars else 1

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -344,7 +344,6 @@ def test_init_immun_scalar():
         "init_prev": 0,
         "pop_scale": 0.01,
         "results_path": None,
-        "run": False,
     }
 
     # Run unscaled version


### PR DESCRIPTION
Includes stricter PropertySet update functionality.

```python
ps += update  # update CANNOT include any keys already present in ps
ps <<= update # keys in update MUST already be present in ps
ps |= update  # keys may or may not be present in ps
```
