### PR TITLE
Fix issue where docker layer caching was not installing fresh laser-p…

### DIFF
--- a/calib/Dockerfile
+++ b/calib/Dockerfile
@@ -8,7 +8,7 @@ ENV NUMBA_CPU_NAME=generic
 ENV HEADLESS=1
 
 
-# Install laser-polio (use cache nullification hack suggetsed by robot)
+# Install laser-polio (use cache nullification hack suggested by robot)
 # Add '--build-arg CACHE_BREAKER=$(date +%s)' to docker build line
 ARG CACHE_BREAKER=1
 RUN pip install -i https://packages.idmod.org/api/pypi/pypi-production/simple laser-polio

--- a/calib/Dockerfile
+++ b/calib/Dockerfile
@@ -7,8 +7,11 @@ ENV POLIO_ROOT=/app
 ENV NUMBA_CPU_NAME=generic
 ENV HEADLESS=1
 
-# Install laser-polio (maximize layer cache)
-RUN pip install --no-cache-dir --upgrade --force-reinstall -i https://packages.idmod.org/api/pypi/pypi-production/simple laser-polio
+
+# Install laser-polio (use cache nullification hack suggetsed by robot)
+# Add '--build-arg CACHE_BREAKER=$(date +%s)' to docker build line
+ARG CACHE_BREAKER=1
+RUN pip install -i https://packages.idmod.org/api/pypi/pypi-production/simple laser-polio
 
 # Copy application code and configuration files
 COPY calib/ ./calib/

--- a/calib/Dockerfile
+++ b/calib/Dockerfile
@@ -11,7 +11,7 @@ ENV HEADLESS=1
 # Install laser-polio (use cache nullification hack suggested by robot)
 # Add '--build-arg CACHE_BREAKER=$(date +%s)' to docker build line
 ARG CACHE_BREAKER=1
-RUN pip install -i https://packages.idmod.org/api/pypi/pypi-production/simple laser-polio
+RUN pip install --upgrade -i https://packages.idmod.org/api/pypi/pypi-production/simple laser-polio
 
 # Copy application code and configuration files
 COPY calib/ ./calib/

--- a/calib/cloud/build_and_push.py
+++ b/calib/cloud/build_and_push.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import sciris as sc
@@ -13,7 +14,24 @@ def run_docker_commands():
     dockerfile = "calib/Dockerfile"
     platform = "linux/amd64"  # Setting for aks. If you're running locally (e.g. on a mac), you'll need to change this to "linux/arm64".
 
-    build_cmd = ["docker", "build", ".", "-f", dockerfile, "-t", image_tag, "--platform", platform]
+    # Generate a cache-busting value (timestamp)
+    cache_breaker = str(int(time.time()))
+
+    # Build command with --build-arg
+    build_cmd = [
+        "docker",
+        "build",
+        ".",
+        "-f",
+        dockerfile,
+        "-t",
+        image_tag,
+        "--platform",
+        platform,
+        "--build-arg",
+        f"CACHE_BREAKER={cache_breaker}",
+    ]
+
     create_cmd = ["docker", "create", "--name", "temp_laser", image_tag]
     cp_cmd = ["docker", "cp", "temp_laser:/app/laser_polio_deps.txt", "./laser_polio_deps.txt"]
     rm_cmd = ["docker", "rm", "temp_laser"]


### PR DESCRIPTION
…olio versions.

Need to amend docker build by adding something like: '--build-arg CACHE_BREAKER=$(date +%s)'. This forces the layer to be cache nullified so docker won't reuse it.

In other news, cache nullification is one of the N things which is hard in software.