### PR TITLE
Sk/strain paralysis

### DIFF
--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -577,7 +577,9 @@ class DiseaseState_ABM:
         # Clip exposure and infection timers to be within the range of 0 and 127 (the max value for an int8)
         sim.people.exposure_timer[:] = np.clip(sim.people.exposure_timer, 0, 127)
         sim.people.infection_timer[:] = np.clip(sim.people.infection_timer, 0, 127)
-        # Initialize time to paralysis (parameterized as time from exposure to paralysis) & ensure it's within the range of exposure and infection timers
+        # The paralysis timer is parameterized as 'time from exposure to paralysis'.
+        # We adjust it to 'time remaining after exposure period' by subtracting the exposure timer.
+        # Then, we clip it to ensure paralysis occurs during the infection period (i.e., after exposure but before recovery).
         raw_paralysis_time = self.pars.t_to_paralysis(sim.people.capacity)
         raw_paralysis_time = raw_paralysis_time - sim.people.exposure_timer
         upper_bound = np.minimum(sim.people.infection_timer, 127)

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -47,10 +47,6 @@ from laser_polio.utils import TimingStats
 __all__ = ["RI_ABM", "SEIR_ABM", "SIA_ABM", "DiseaseState_ABM", "Transmission_ABM", "VitalDynamics_ABM"]
 
 
-# TODO:
-# - Test that Sabin & nOPV2 strains do NOT cause paralysis
-
-
 # SEIR Model
 class SEIR_ABM:
     """
@@ -427,9 +423,10 @@ def disease_state_step_kernel(
 
         # ---- Paralysis ----
         if disease_state[i] == 2:
+            # Paralysis can only occur during the infected stage
             # Paralysis timer is parameterized as time from exposure to paralysis. During initialization, it's trimmed to be within the range of the exposure and infection timers.
-            if paralysis_timer[i] <= 0:
-                if strain[i] == 0:
+            if strain[i] == 0:
+                if paralysis_timer[i] <= 0:
                     if potentially_paralyzed[i] == -1:
                         # If infected with a paralytic strain and not yet potentially paralyzed
                         if ipv_protected[i] == 0:
@@ -441,7 +438,7 @@ def disease_state_step_kernel(
                         else:
                             # Explicitly set to 0 if ipv_protected
                             potentially_paralyzed[i] = 0
-                    paralysis_timer[i] -= 1  # Only decrement if it's a paralytic strain
+                paralysis_timer[i] -= 1  # Only decrement if it's a paralytic strain
 
         if was_potentially_paralyzed:
             local_new_potential[tid, nid] += 1

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -47,6 +47,10 @@ from laser_polio.utils import TimingStats
 __all__ = ["RI_ABM", "SEIR_ABM", "SIA_ABM", "DiseaseState_ABM", "Transmission_ABM", "VitalDynamics_ABM"]
 
 
+# TODO:
+# - Test that Sabin & nOPV2 strains do NOT cause paralysis
+
+
 # SEIR Model
 class SEIR_ABM:
     """
@@ -345,6 +349,7 @@ def disease_state_step(
     node_id,
     n_nodes,
     disease_state,
+    strain,
     active_count,
     exposure_timer,
     infection_timer,
@@ -371,6 +376,7 @@ def disease_state_step(
         node_id,
         n_nodes,
         disease_state,
+        strain,
         active_count,
         exposure_timer,
         infection_timer,
@@ -393,6 +399,7 @@ def disease_state_step_kernel(
     node_id,
     n_nodes,
     disease_state,
+    strain,
     active_count,
     exposure_timer,
     infection_timer,
@@ -418,36 +425,35 @@ def disease_state_step_kernel(
                 disease_state[i] = 2  # Become infected
             exposure_timer[i] -= 1
 
+        # ---- Paralysis ----
+        if disease_state[i] == 2:
+            # Paralysis timer is parameterized as time from exposure to paralysis. During initialization, it's trimmed to be within the range of the exposure and infection timers.
+            if paralysis_timer[i] <= 0:
+                if strain[i] == 0 and potentially_paralyzed[i] == -1:
+                    # If infected with a paralytic strain and not yet potentially paralyzed
+                    if ipv_protected[i] == 0:
+                        potentially_paralyzed[i] = 1
+                        was_potentially_paralyzed = True
+                        if np.random.random() < p_paralysis:
+                            paralyzed[i] = 1
+                            was_paralyzed = True
+                    else:
+                        # Explicitly set to 0 if ipv_protected
+                        potentially_paralyzed[i] = 0
+            paralysis_timer[i] -= 1
+
+        if was_potentially_paralyzed:
+            local_new_potential[tid, nid] += 1
+        if was_paralyzed:
+            local_new_paralyzed[tid, nid] += 1
+
         # ---- Infected to Recovered Transition ----
         if disease_state[i] == 2:  # Infected
             if infection_timer[i] <= 0:
                 disease_state[i] = 3  # Become recovered
             infection_timer[i] -= 1
 
-        # ---- Paralysis ----
-        if disease_state[i] in (1, 2, 3):
-            # NOTE: Currently we don't have strain tracking, so I had to set potentially_paralyzed to 0 in SIA_ABM & RI_ABM, otherwise those interventions would cause potential paralysis cases.
-            # TODO: revise when we have strain stracking
-            # TODO: remove the potential_paralysis attributes from RI & SIAs after we have strain tracking
-            # Any time after exposure, but not yet potentially paralyzed
-            if potentially_paralyzed[i] == -1:  # after exposure, but not yet flagged
-                if paralysis_timer[i] <= 0:
-                    if ipv_protected[i] == 0:
-                        potentially_paralyzed[i] = 1
-                        was_potentially_paralyzed = True
-                        # Numba supports np.random.random() in nopython mode
-                        if np.random.random() < p_paralysis:
-                            paralyzed[i] = 1
-                            was_paralyzed = True
-                    else:
-                        # Explicitly set to 0 if protected
-                        potentially_paralyzed[i] = 0
-                paralysis_timer[i] -= 1
-
-        if was_potentially_paralyzed:
-            local_new_potential[tid, nid] += 1
-        if was_paralyzed:
-            local_new_paralyzed[tid, nid] += 1
+    return
 
 
 @nb.njit(parallel=True, cache=True)
@@ -558,22 +564,28 @@ class DiseaseState_ABM:
         self._common_init(sim)
         self._initialize_results_arrays()
         self.verbose = sim.pars["verbose"] if "verbose" in sim.pars else 1
-
-        # Initialize all agents with an exposure_timer, infection_timer, and paralysis_timer
-        sim.people.add_scalar_property("exposure_timer", dtype=np.uint8, default=0)
-        sim.people.exposure_timer[:] = self.pars.dur_exp(self.people.capacity)
-        sim.people.add_scalar_property("infection_timer", dtype=np.uint8, default=0)
-        sim.people.infection_timer[:] = self.pars.dur_inf(self.people.capacity)
-        sim.people.add_scalar_property("paralysis_timer", dtype=np.uint8, default=0)
-        sim.people.paralysis_timer[:] = self.pars.t_to_paralysis(self.people.capacity)
-
         pars = self.pars
 
-        # logger.debug(f"Before immune initialization, we have {sim.people.count} active agents.")
-        if self.verbose >= 2:
-            print(f"Before immune initialization, we have {sim.people.count} active agents.")
+        # -- Initialize timers --
+        sim.people.add_scalar_property("exposure_timer", dtype=np.int8, default=0)
+        sim.people.add_scalar_property("infection_timer", dtype=np.int8, default=0)
+        sim.people.add_scalar_property("paralysis_timer", dtype=np.int8, default=0)
+        # Initialize exposure and infection timers
+        sim.people.exposure_timer[:] = self.pars.dur_exp(sim.people.capacity)
+        sim.people.infection_timer[:] = self.pars.dur_inf(sim.people.capacity)
+        # Clip exposure and infection timers to be within the range of 0 and 127 (the max value for anint8)
+        sim.people.exposure_timer[:] = np.clip(sim.people.exposure_timer, 0, 127)
+        sim.people.infection_timer[:] = np.clip(sim.people.infection_timer, 0, 127)
+        # Initialize time to paralysis (parameterized as time from exposure to paralysis) & ensure it's within the range of exposure and infection timers
+        raw_paralysis_time = self.pars.t_to_paralysis(sim.people.capacity)
+        raw_paralysis_time = raw_paralysis_time - sim.people.exposure_timer
+        paralysis_timer = np.clip(raw_paralysis_time, 0, sim.people.infection_timer).astype(np.int8)
+        paralysis_timer = np.clip(paralysis_timer, 0, 127)
+        sim.people.paralysis_timer[:] = paralysis_timer
 
         # -- Initialize immunity --
+        if self.verbose >= 2:
+            print(f"Before immune initialization, we have {sim.people.count} active agents.")
         if pars.init_sus_by_age is None:
             # Normalize init_immun into per-node immunity fractions
             if isinstance(pars.init_immun, float):
@@ -708,6 +720,7 @@ class DiseaseState_ABM:
             node_id=self.people.node_id,
             n_nodes=n_nodes,
             disease_state=self.people.disease_state,
+            strain=self.people.strain,
             active_count=self.people.count,
             exposure_timer=self.people.exposure_timer,
             infection_timer=self.people.infection_timer,
@@ -1781,7 +1794,6 @@ def get_deaths(num_nodes, num_people, disease_state, node_id, date_of_death, t, 
         nb.int32[:, :],
         nb.int32[:, :],
         nb.uint8[:],
-        nb.int8[:],
         nb.int8,
     ),
     parallel=True,
@@ -1802,7 +1814,6 @@ def fast_ri(
     local_ri_protected,
     local_ipv_counts,
     chronically_missed,
-    potentially_paralyzed,
     ri_vaccine_strain,
 ):
     """
@@ -1835,12 +1846,9 @@ def fast_ri(
                     disease_state[i] = 1  # Set to exposed
                     strain[i] = ri_vaccine_strain  # Set vaccine strain
                     local_ri_protected[nb.get_thread_id(), node] += 1  # Increment protected count
-                    # TODO remove when we have strain tracking hooked up into paralysis
-                    potentially_paralyzed[i] = 0  # Assume that vaccine strains don't cause paralysis
             if np.random.rand() < prob_ipv:
                 local_ipv_counts[nb.get_thread_id(), node] += 1
                 ipv_protected[i] = 1
-
     return
 
 
@@ -1953,7 +1961,6 @@ class RI_ABM:
                 local_ri_protected=local_ri_protected,
                 local_ipv_counts=local_ipv_counts,
                 chronically_missed=self.people.chronically_missed,
-                potentially_paralyzed=self.people.potentially_paralyzed,
                 ri_vaccine_strain=ri_vaccine_strain,
             )
             # Sum up the counts from all threads
@@ -1997,7 +2004,6 @@ def fast_sia(
     local_vaccinated,
     local_protected,
     chronically_missed,
-    potentially_paralyzed,
     sia_vaccine_strain,
 ):
     """
@@ -2017,7 +2023,6 @@ def fast_sia(
         local_vaccinated: Output array for vaccinated counts (threads x nodes).
         local_protected: Output array for protected counts (threads x nodes).
         chronically_missed: Array indicating chronically missed individuals.
-        potentially_paralyzed: Array for paralysis tracking.
         sia_vaccine_strain: Integer strain ID for this vaccine type.
     """
     num_people = count
@@ -2049,9 +2054,6 @@ def fast_sia(
                     disease_states[i] = 1  # Move to Exposed state (vaccine infection)
                     strain[i] = sia_vaccine_strain  # Set vaccine strain
                     local_protected[thread_id, node] += 1  # Increment protected count
-                    # TODO remove when we have strain tracking hooked up into paralysis
-                    potentially_paralyzed[i] = 0  # Vaccine strains don't cause paralysis
-
     return
 
 
@@ -2132,7 +2134,6 @@ class SIA_ABM:
                     local_vaccinated,
                     local_protected,
                     chronically_missed=self.people.chronically_missed,
-                    potentially_paralyzed=self.people.potentially_paralyzed,
                     sia_vaccine_strain=sia_vaccine_strain,
                 )
                 self.results.sia_vaccinated[t] = local_vaccinated.sum(

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -565,6 +565,9 @@ class DiseaseState_ABM:
         pars = self.pars
 
         # -- Initialize timers --
+        # NOTE: Timers are now stored as np.int8 instead of np.uint8.
+        # This reduces the maximum timer value from 255 to 127 days.
+        # The change is intentional: timer values are clipped to 127, and int8 may be preferred for memory savings or to allow negative values if needed.
         sim.people.add_scalar_property("exposure_timer", dtype=np.int8, default=0)
         sim.people.add_scalar_property("infection_timer", dtype=np.int8, default=0)
         sim.people.add_scalar_property("paralysis_timer", dtype=np.int8, default=0)

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -577,8 +577,8 @@ class DiseaseState_ABM:
         # Initialize time to paralysis (parameterized as time from exposure to paralysis) & ensure it's within the range of exposure and infection timers
         raw_paralysis_time = self.pars.t_to_paralysis(sim.people.capacity)
         raw_paralysis_time = raw_paralysis_time - sim.people.exposure_timer
-        paralysis_timer = np.clip(raw_paralysis_time, 0, sim.people.infection_timer).astype(np.int8)
-        paralysis_timer = np.clip(paralysis_timer, 0, 127)
+        upper_bound = np.minimum(sim.people.infection_timer, 127)
+        paralysis_timer = np.clip(raw_paralysis_time, 0, upper_bound).astype(np.int8)
         sim.people.paralysis_timer[:] = paralysis_timer
 
         # -- Initialize immunity --

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -421,9 +421,15 @@ def disease_state_step_kernel(
                 disease_state[i] = 2  # Become infected
             exposure_timer[i] -= 1
 
-        # ---- Paralysis ----
+        # ---- Infected & paralysis ----
         if disease_state[i] == 2:
-            # Paralysis can only occur during the infected stage
+            # ---- Infected to Recovered Transition ----
+            if infection_timer[i] <= 0:
+                disease_state[i] = 3  # Become recovered
+            infection_timer[i] -= 1
+
+            # ---- Paralysis ----
+            # Paralysis can only occur during the infected stage & only for paralytic strains
             # Paralysis timer is parameterized as time from exposure to paralysis. During initialization, it's trimmed to be within the range of the exposure and infection timers.
             if strain[i] == 0:
                 if paralysis_timer[i] <= 0:
@@ -440,16 +446,10 @@ def disease_state_step_kernel(
                             potentially_paralyzed[i] = 0
                 paralysis_timer[i] -= 1  # Only decrement if it's a paralytic strain
 
-        if was_potentially_paralyzed:
-            local_new_potential[tid, nid] += 1
-        if was_paralyzed:
-            local_new_paralyzed[tid, nid] += 1
-
-        # ---- Infected to Recovered Transition ----
-        if disease_state[i] == 2:  # Infected
-            if infection_timer[i] <= 0:
-                disease_state[i] = 3  # Become recovered
-            infection_timer[i] -= 1
+            if was_potentially_paralyzed:
+                local_new_potential[tid, nid] += 1
+            if was_paralyzed:
+                local_new_paralyzed[tid, nid] += 1
 
     return
 

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -429,18 +429,19 @@ def disease_state_step_kernel(
         if disease_state[i] == 2:
             # Paralysis timer is parameterized as time from exposure to paralysis. During initialization, it's trimmed to be within the range of the exposure and infection timers.
             if paralysis_timer[i] <= 0:
-                if strain[i] == 0 and potentially_paralyzed[i] == -1:
-                    # If infected with a paralytic strain and not yet potentially paralyzed
-                    if ipv_protected[i] == 0:
-                        potentially_paralyzed[i] = 1
-                        was_potentially_paralyzed = True
-                        if np.random.random() < p_paralysis:
-                            paralyzed[i] = 1
-                            was_paralyzed = True
-                    else:
-                        # Explicitly set to 0 if ipv_protected
-                        potentially_paralyzed[i] = 0
-            paralysis_timer[i] -= 1
+                if strain[i] == 0:
+                    if potentially_paralyzed[i] == -1:
+                        # If infected with a paralytic strain and not yet potentially paralyzed
+                        if ipv_protected[i] == 0:
+                            potentially_paralyzed[i] = 1
+                            was_potentially_paralyzed = True
+                            if np.random.random() < p_paralysis:
+                                paralyzed[i] = 1
+                                was_paralyzed = True
+                        else:
+                            # Explicitly set to 0 if ipv_protected
+                            potentially_paralyzed[i] = 0
+                    paralysis_timer[i] -= 1  # Only decrement if it's a paralytic strain
 
         if was_potentially_paralyzed:
             local_new_potential[tid, nid] += 1

--- a/src/laser_polio/model.py
+++ b/src/laser_polio/model.py
@@ -446,10 +446,10 @@ def disease_state_step_kernel(
                             potentially_paralyzed[i] = 0
                 paralysis_timer[i] -= 1  # Only decrement if it's a paralytic strain
 
-            if was_potentially_paralyzed:
-                local_new_potential[tid, nid] += 1
-            if was_paralyzed:
-                local_new_paralyzed[tid, nid] += 1
+                if was_potentially_paralyzed:
+                    local_new_potential[tid, nid] += 1
+                if was_paralyzed:
+                    local_new_paralyzed[tid, nid] += 1
 
     return
 

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -537,8 +537,8 @@ def test_paralysis_progression_manual():
         "People that move through the I stage (E & I; not S & R) who are not ipv protected should be paralyzed"
     )
 
-    assert np.sum(sim.results.potentially_paralyzed[-1]) == 2, "Should have 3 potentially paralyzed individuals"
-    assert np.sum(sim.results.paralyzed[-1]) == 2, "Should have 3 paralyzed individuals"
+    assert np.sum(sim.results.potentially_paralyzed[-1]) == 2, "Should have 2 potentially paralyzed individuals"
+    assert np.sum(sim.results.paralyzed[-1]) == 2, "Should have 2 paralyzed individuals"
 
 
 def test_paralysis_fraction_sans_ipv():

--- a/tests/test_diseasestate_abm.py
+++ b/tests/test_diseasestate_abm.py
@@ -301,7 +301,8 @@ def test_disease_timers_with_trans_explicit():
     p_timers = sim.people.paralysis_timer[:]
     assert np.all(e_timers == dur_exp), "Exposure timers should be equal to dur_exp"
     assert np.all(i_timers == dur_inf), "Infection timers should be equal to dur_inf"
-    assert np.all(p_timers == t_to_paralysis), "Paralysis timers should be equal to t_to_paralysis"
+    assert np.all(p_timers >= e_timers), "Paralysis timers should be greater than or equal to exposure timers"
+    assert np.all(p_timers <= i_timers), "Paralysis timers should be less than or equal to infection timers"
 
     # Run the simulation for one timestep
     sim.run()
@@ -311,7 +312,7 @@ def test_disease_timers_with_trans_explicit():
     n_e = np.sum(sim.results.E, axis=1)
     n_i = np.sum(sim.results.I, axis=1)
     n_r = np.sum(sim.results.R, axis=1)
-    n_p = np.sum(sim.results.new_potentially_paralyzed, axis=1)
+    n_npp = np.sum(sim.results.new_potentially_paralyzed, axis=1)
 
     # Calc time to state changes
     zeros = np.zeros(sim.pars.dur + 1).astype(int)
@@ -335,15 +336,19 @@ def test_disease_timers_with_trans_explicit():
     n_r_exp[(2 + dur_exp + dur_inf) :] += 1  # new infections should recover after dur_exp days
     # P
     n_p_exp = zeros.copy()
-    n_p_exp[1 + t_to_paralysis] += 1  # The seeded infection should become P after t_to_paralysis days (+1 for day 0)
-    n_p_exp[2 + t_to_paralysis] += 1  # The new infection should become E on day 1 (super high r0) then become P after t_to_paralysis days
+    n_p_exp[1 + dur_inf] += (
+        1  # The seeded infection should become P after dur_inf (b/c t_to_paralysis gets clipped to be within the range of exposure and infection timers) days (+1 for day 0)
+    )
+    n_p_exp[2 + dur_exp + dur_inf] += (
+        1  # The new infection should become E on day 1 (super high r0) then become P after dur_exp + dur_inf days
+    )
 
     # Check that the results match the expected counts
     assert np.all(n_s == n_s_exp), "S counts should match expected counts"
     assert np.all(n_e == n_e_exp), "E counts should match expected counts"
     assert np.all(n_i == n_i_exp), "I counts should match expected counts"
     assert np.all(n_r == n_r_exp), "R counts should match expected counts"
-    assert np.all(n_p == n_p_exp), "P counts should match expected counts"
+    assert np.all(n_npp == n_p_exp), "P counts should match expected counts"
 
 
 # Test Paralysis Probability
@@ -481,10 +486,11 @@ def test_init_immun_scalar():
 def test_time_to_paralysis():
     sim = setup_sim()
     dist = sim.pars.t_to_paralysis(1000)
+    e_timer = sim.people.exposure_timer
     p_timer = sim.people.paralysis_timer
     assert np.isclose(dist.mean(), 12.5, atol=3)
     assert np.isclose(dist.std(), 3.5, atol=3)
-    assert np.isclose(p_timer.mean(), 12.5, atol=3)
+    assert np.isclose(p_timer.mean() + e_timer.mean(), 12.5, atol=3)
     assert np.isclose(p_timer.std(), 3.5, atol=3)
 
 
@@ -522,15 +528,17 @@ def test_paralysis_progression_manual():
     assert np.sum(sim.people.potentially_paralyzed[protected_idx] <= 0) == 4, (
         "SEIR people who are protected should not be potentially paralyzed"
     )
-    assert np.sum(sim.people.potentially_paralyzed[unprotected_idx] > 0) == 3, (
-        "EIR (not S) People who are not protected should be potentially paralyzed"
+    assert np.sum(sim.people.potentially_paralyzed[unprotected_idx] > 0) == 2, (
+        "People that move through the I stage (E & I; not S & R) who are not ipv protected should be potentially paralyzed"
     )
 
     assert np.sum(sim.people.paralyzed[protected_idx] <= 0) == 4, "SEIR people who are protected should not be paralyzed"
-    assert np.sum(sim.people.paralyzed[unprotected_idx] > 0) == 3, "EIR (not S) People who are not protected should be paralyzed"
+    assert np.sum(sim.people.paralyzed[unprotected_idx] > 0) == 2, (
+        "People that move through the I stage (E & I; not S & R) who are not ipv protected should be paralyzed"
+    )
 
-    assert np.sum(sim.results.potentially_paralyzed[-1]) == 3, "Should have 3 potentially paralyzed individuals"
-    assert np.sum(sim.results.paralyzed[-1]) == 3, "Should have 3 paralyzed individuals"
+    assert np.sum(sim.results.potentially_paralyzed[-1]) == 2, "Should have 3 potentially paralyzed individuals"
+    assert np.sum(sim.results.paralyzed[-1]) == 2, "Should have 3 paralyzed individuals"
 
 
 def test_paralysis_fraction_sans_ipv():
@@ -654,12 +662,26 @@ def test_potential_paralysis():
         use_pim_scalars=use_pim_scalars,
     )
 
+    assert len(np.unique(sim.people.strain[:])) > 1, "Should have at least 2 strains to test impacts of paralytic and non-paralytic strains"
+
     assert np.sum(sim.results.new_potentially_paralyzed) <= np.sum(sim.results.new_exposed), (
         "Potential paralysis should be less than or equal to new exposed"
     )
     assert np.isclose(np.sum(sim.results.new_potentially_paralyzed) / 2000, np.sum(sim.results.new_paralyzed), atol=17), (
         "Potential paralysis should be 1/2000 of new exposed"
     )
+
+    # Test that potential paralysis only occurs for paralytic strains
+    mask_paralytic = sim.people.strain[:] == 0
+    assert np.isin(sim.people.potentially_paralyzed[mask_paralytic], [-1, 0, 1]).all(), (
+        "Potential paralysis can occur for paralytic strains"
+    )
+    assert np.isin(sim.people.potentially_paralyzed[~mask_paralytic], [-1]).all(), (
+        "Potential paralysis should NOT occur for non-paralytic strains"
+    )
+
+    assert np.isin(sim.people.paralyzed[mask_paralytic], [0, 1]).all(), "Paralysis can occur for paralytic strains"
+    assert np.isin(sim.people.paralyzed[~mask_paralytic], [0]).all(), "Paralysis should NOT occur for non-paralytic strains"
 
 
 if __name__ == "__main__":

--- a/tests_scientific/seasonality_nigeria_7y.py
+++ b/tests_scientific/seasonality_nigeria_7y.py
@@ -1,0 +1,233 @@
+import os
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import laser_polio as lp
+
+###################################
+######### USER PARAMETERS #########
+
+# Sweep parameters
+r0s = [5, 10, 15]
+seasonal_amplitudes = [0.1, 0.5, 0.9]
+seasonal_peak_doys = [120, 165, 210]
+n_reps = 2
+
+# Base parameters
+regions = ["NIGERIA:JIGAWA", "NIGERIA:ZAMFARA", "NIGERIA:NIGER"]
+start_year = 2017
+n_days = 365 * 2
+pop_scale = 1
+init_region = "BIRINIWA"
+init_prev = 0
+seed_schedule = [
+    {"date": "2017-10-01", "dot_name": "AFRO:NIGERIA:JIGAWA:HADEJIA", "prevalence": 100},
+    {"date": "2017-10-01", "dot_name": "AFRO:NIGERIA:JIGAWA:GARKI", "prevalence": 100},
+    {"date": "2020-07-01", "dot_name": "AFRO:NIGERIA:ZAMFARA:TALATA_MAFARA", "prevalence": 100},
+    {"date": "2020-10-01", "dot_name": "AFRO:NIGERIA:NIGER:SULEJA", "prevalence": 100},
+]
+r0 = 10
+migration_method = "radiation"
+node_seeding_dispersion = 1.0
+max_migr_frac = 0.1
+vx_prob_ri = 0.0
+use_pim_scalars = False
+results_path = "results/tests_scientific/seasonality_jigawa_zamfara_niger_7y"
+
+
+######### END OF USER PARS ########
+###################################
+
+# Create result storage
+infected_timeseries = {}
+npp_timeseries = {}
+infected_timeseries_average = {}
+npp_timeseries_average = {}
+
+infected_sum = defaultdict(lambda: np.zeros(n_days + 1, dtype=np.float64))
+npp_sum = defaultdict(lambda: np.zeros(n_days + 1, dtype=np.float64))
+rep_count = defaultdict(int)
+
+infected_timeseries_average = {}
+npp_timeseries_average = {}
+
+print(f"Running seasonality sweep with {len(r0s)} r0s x {len(seasonal_amplitudes)} amplitudes x {len(seasonal_peak_doys)} peak days")
+
+# Run sweep
+for r0 in r0s:
+    for seasonal_amplitude in seasonal_amplitudes:
+        for seasonal_peak_doy in seasonal_peak_doys:
+            key = (r0, seasonal_amplitude, seasonal_peak_doy)
+
+            print(f"\nRunning R0={r0}, amplitude={seasonal_amplitude}, peak_doy={seasonal_peak_doy}")
+
+            for rep in range(n_reps):
+                print(f"  ↳ Rep {rep + 1}/{n_reps}")
+
+                if key == (r0s[0], seasonal_amplitudes[0], seasonal_peak_doys[0]) and rep == 0:
+                    save_plots = True
+                    results_path_sim = results_path + f"/sim_r0_{r0}_amp_{seasonal_amplitude}_peak_{seasonal_peak_doy}_rep_{rep}"
+                else:
+                    save_plots = False
+                    results_path_sim = results_path
+
+                sim = lp.run_sim(
+                    regions=regions,
+                    start_year=start_year,
+                    n_days=n_days,
+                    pop_scale=pop_scale,
+                    init_region=init_region,
+                    init_prev=init_prev,
+                    seed_schedule=seed_schedule,
+                    r0=r0,
+                    migration_method=migration_method,
+                    max_migr_frac=max_migr_frac,
+                    vx_prob_ri=vx_prob_ri,
+                    use_pim_scalars=use_pim_scalars,
+                    seasonal_amplitude=seasonal_amplitude,
+                    seasonal_peak_doy=seasonal_peak_doy,
+                    results_path=results_path + f"/sim_r0_{r0}_amp_{seasonal_amplitude}_peak_{seasonal_peak_doy}_rep_{rep}",
+                    save_plots=save_plots,
+                    save_data=False,
+                    verbose=0,
+                    seed=rep,
+                    run=True,
+                )
+
+                # Per-rep daily series
+                inf_ts = np.sum(sim.results.I_by_strain[:, :, 0], axis=1)
+                npp_ts = np.sum(sim.results.new_potentially_paralyzed, axis=1)
+
+                # (Optional) keep per-rep if you still want them
+                key_rep = (r0, seasonal_amplitude, seasonal_peak_doy, rep)
+                infected_timeseries[key_rep] = inf_ts
+                npp_timeseries[key_rep] = npp_ts
+
+                # Accumulate for average
+                infected_sum[key] += inf_ts
+                npp_sum[key] += npp_ts
+                rep_count[key] += 1
+
+            # finalize averages for this combo
+            infected_timeseries_average[key] = infected_sum[key] / rep_count[key]
+            npp_timeseries_average[key] = npp_sum[key] / rep_count[key]
+
+
+os.makedirs(results_path, exist_ok=True)
+
+# Create plots
+print("\nCreating plots...")
+
+
+def _plot_metric_for_r0(
+    r0,
+    metric_name,  # "infected" or "npp"
+    per_rep_dict,  # e.g., infected_timeseries or npp_timeseries
+    avg_dict,  # e.g., infected_timeseries_average or npp_timeseries_average
+    seasonal_amplitudes,
+    seasonal_peak_doys,
+    n_reps,
+    n_days,
+    results_path,
+    ylabel,
+    filename_prefix,
+):
+    nrows, ncols = len(seasonal_amplitudes), len(seasonal_peak_doys)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(3.5 * ncols, 2.8 * nrows), sharex=True, sharey=True)
+    axes = np.atleast_2d(axes)
+    fig.suptitle(f"{metric_name.upper()} over time (sum over nodes) — Seasonality Sweep — R0={r0}", fontsize=16)
+
+    # Ensure save dir
+    os.makedirs(results_path, exist_ok=True)
+
+    first_rep_plotted = False  # for legend labeling
+    first_mean_plotted = False
+
+    for i, seasonal_amplitude in enumerate(seasonal_amplitudes):
+        for j, seasonal_peak_doy in enumerate(seasonal_peak_doys):
+            ax = axes[i, j]
+
+            # 1) Plot each replicate (light lines)
+            rep_series = []
+            for rep in range(n_reps):
+                k = (r0, seasonal_amplitude, seasonal_peak_doy, rep)
+                ts = per_rep_dict.get(k)
+                if ts is None:
+                    continue
+                ts = np.asarray(ts)
+                rep_series.append(ts)
+                ax.plot(ts, alpha=0.30, linewidth=1.0, label="Replicate" if not first_rep_plotted else None)
+                first_rep_plotted = True
+
+            # 2) Plot mean across reps (thick line)
+            base_key = (r0, seasonal_amplitude, seasonal_peak_doy)
+            mean_ts = avg_dict.get(base_key)
+
+            # If the precomputed mean is missing, compute it from whatever reps we have
+            if mean_ts is None:
+                if rep_series:
+                    mean_ts = np.mean(np.stack(rep_series, axis=0), axis=0)
+                else:
+                    # fallback to zeros if nothing is present
+                    mean_ts = np.zeros(n_days, dtype=float)
+
+            mean_ts = np.asarray(mean_ts)
+            ax.plot(mean_ts, linewidth=2.5, label="Mean across reps" if not first_mean_plotted else None)
+            first_mean_plotted = True
+
+            ax.set_title(f"Amp={seasonal_amplitude}, Peak DoY={seasonal_peak_doy}")
+            ax.grid(True, alpha=0.3)
+            if i == nrows - 1:
+                ax.set_xlabel("Time (days)")
+            if j == 0:
+                ax.set_ylabel(ylabel)
+
+    # Single legend
+    handles, labels = axes[0, 0].get_legend_handles_labels()
+    if handles:
+        fig.legend(handles, labels, loc="upper right", frameon=False)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.97])
+    outfile = os.path.join(results_path, f"{filename_prefix}_r0_{r0}.png")
+    plt.savefig(outfile, dpi=300, bbox_inches="tight")
+    plt.close()
+    print(f"Saved: {outfile}")
+
+
+# =======================
+# Call for each R0 & metric
+# =======================
+for r0 in r0s:
+    # Infected
+    _plot_metric_for_r0(
+        r0=r0,
+        metric_name="infected",
+        per_rep_dict=infected_timeseries,  # keys: (r0, amp, peak, rep)
+        avg_dict=infected_timeseries_average,  # keys: (r0, amp, peak)
+        seasonal_amplitudes=seasonal_amplitudes,
+        seasonal_peak_doys=seasonal_peak_doys,
+        n_reps=n_reps,
+        n_days=n_days,
+        results_path=results_path,
+        ylabel="Infected (sum over nodes)",
+        filename_prefix="infected_time_series",
+    )
+
+    # NPP
+    _plot_metric_for_r0(
+        r0=r0,
+        metric_name="npp",
+        per_rep_dict=npp_timeseries,  # keys: (r0, amp, peak, rep)
+        avg_dict=npp_timeseries_average,  # keys: (r0, amp, peak)
+        seasonal_amplitudes=seasonal_amplitudes,
+        seasonal_peak_doys=seasonal_peak_doys,
+        n_reps=n_reps,
+        n_days=n_days,
+        results_path=results_path,
+        ylabel="New Potentially Paralyzed (sum over nodes)",
+        filename_prefix="npp_time_series",
+    )
+
+print("Done!")

--- a/tests_scientific/seasonality_zamfara_1y.py
+++ b/tests_scientific/seasonality_zamfara_1y.py
@@ -23,7 +23,7 @@ max_migr_frac = 0.1
 vx_prob_ri = 0.0
 missed_frac = 0.1
 use_pim_scalars = False
-results_path = "results/tests_scientific/seasonality"
+results_path = "results/tests_scientific/seasonality_zamfara_1y"
 
 # No seed schedule for simplicity - just use init_prev
 seed_schedule = None


### PR DESCRIPTION
Previously, we were incorrectly allowing any strain to cause paralysis. We'd put in some guard rails to prevent those (e.g., potential_paralysis logic in the RI & SIAs), but those apparently didn't work correctly.

This PR refactors the paralysis logic: 
- it sets the exposure, infection, and paralysis timers to int8
- it clips the above timers to be within 0 and 127 during initialization
- it forces the the paralysis timer to occur after exposure but before the infection timer ends
- it only checks for paralysis if the agent is infected with a paralytic strain (strain 0)