### PR TITLE
Refactoring cases_by_month calib target

### DIFF
--- a/calib/calib_configs/synth_nga_doy.yaml
+++ b/calib/calib_configs/synth_nga_doy.yaml
@@ -1,0 +1,17 @@
+parameters:
+  seasonal_peak_doy:
+    low: 0
+    high: 360
+    
+metadata:
+  scoring_fn: compute_nll_dirichlet
+  target_fn: calc_targets_regional_by_period
+  weights:
+    cases_total: 0.0
+    cases_by_period: 0.0
+    cases_by_monthly_timeseries: 0.0
+    cases_by_month: 1.0
+    cases_by_region: 0.0
+    cases_by_region_period: 0.0
+    cases_by_region_month: 0.0
+    case_bins_by_region: 0.0

--- a/calib/calibrate.py
+++ b/calib/calibrate.py
@@ -17,13 +17,13 @@ import laser_polio as lp
 
 # ------------------- USER CONFIGS -------------------
 
-# study_name = "calib_zamfara_20250822"
-# model_config = "config_zamfara.yaml"
-# calib_config = "r0.yaml"
+study_name = "calib_zamfara_20250822"
+model_config = "config_zamfara.yaml"
+calib_config = "r0.yaml"
 
-study_name = "calib_nigeria_7y_2017_underwt_regions_maxmigrfrac_dm_fix_20250822"
-model_config = "config_nigeria_7y_2017_regions_sansmaxmigrfrac.yaml"
-calib_config = "r0_k_ssn_wts_maxmigrfrac.yaml"
+# study_name = "calib_nigeria_7y_2017_underwt_regions_maxmigrfrac_dm_fix_20250822"
+# model_config = "config_nigeria_7y_2017_regions_sansmaxmigrfrac.yaml"
+# calib_config = "r0_k_ssn_wts_maxmigrfrac.yaml"
 
 fit_function = "log_likelihood"
 n_trials = 2

--- a/calib/targets.py
+++ b/calib/targets.py
@@ -310,9 +310,13 @@ def calc_targets_regional(filename, model_config_path=None, is_actual_data=True)
     cases_by_period = df.groupby("time_period", observed=True)[case_col].sum() * scale_factor
     targets["cases_by_period"] = cases_by_period.to_dict()
 
-    # Total cases by month
+    # Total cases by month and year (e.g., 2018-01, 2018-02, etc.)
     monthly_df = df.groupby([df["date"].dt.to_period("M")])[case_col].sum().sort_index().astype(float) * scale_factor
-    targets["cases_by_month"] = monthly_df.values
+    targets["cases_by_monthly_timeseries"] = monthly_df.values
+
+    # Total cases by month number (1-12) across all years
+    cases_by_month_across_years = monthly_df.groupby(monthly_df.index.month).sum()
+    targets["cases_by_month"] = cases_by_month_across_years.values
 
     # Total cases by region (across all time periods)
     cases_by_region = df.groupby("region")[case_col].sum() * scale_factor


### PR DESCRIPTION
Renames cases_by_month as cases_by_monthly_timeseries. 

Adds a cases_by_month target (total for all Januarys)

Adds a config that only targets the cases_by_month